### PR TITLE
Cleaned up the code to call the kalman estimation function...

### DIFF
--- a/matlab_simulation/01-examples_lecture/mr-5-kalmamfilter/kf_example1.m
+++ b/matlab_simulation/01-examples_lecture/mr-5-kalmamfilter/kf_example1.m
@@ -76,7 +76,7 @@ for t=1:length(T)
     S_old = S;
     
     % Kalman Filter Estimation
-    [mu,S,mup,Sp,K] = kalman_filter(ssm,mu,S,u(:,t),y(:,t),example,t,freq);
+    [mu,S,mup,Sp,K] = kalman_filter(ssm,mu,S,u(:,t),y(:,t));
     
     % Store estimates
     mup_S(t)= mup;

--- a/matlab_simulation/01-examples_lecture/mr-5-kalmamfilter/kf_example2.m
+++ b/matlab_simulation/01-examples_lecture/mr-5-kalmamfilter/kf_example2.m
@@ -79,7 +79,7 @@ for t=2:length(T)
 
     
     %% Kalman Filter Estimation
-    [mu,S,mup,Sp,K] = kalman_filter(ssm,mu,S,u(:,t),y(:,t),example,t,freq);
+    [mu,S,mup,Sp,K] = kalman_filter(ssm,mu,S,u(:,t),y(:,t));
     
     % Store results
     mup_S(:,t) = mup;

--- a/matlab_simulation/01-examples_lecture/mr-5-particlefilter/particle_filter.m
+++ b/matlab_simulation/01-examples_lecture/mr-5-particlefilter/particle_filter.m
@@ -1,6 +1,4 @@
-addpath('./lib')
-addpath('./lib/particle_filter')
-clear;
+clear; close all;
 clc;
 
 % Discrete time step
@@ -15,7 +13,7 @@ mu_old = mu;
 S_old = S;
 
 % Number of particles
-M = 100;
+M = 500;
 
 % Prior - uniform over 5 15
 X = 5 + 10 * rand(1, M);
@@ -63,7 +61,7 @@ for t = 1:length(T)
         u(t) = u(t - 1);
     end
     if (mu > 10)
-        u(t) = 0
+        u(t) = 0;
     elseif (mu < 2)
         u(t) = 1;
     end
@@ -77,10 +75,10 @@ for t = 1:length(T)
     y(t) = C * x(t + 1) + d;
 
     % kalman filter estimation
-    [mu,S,mup,Sp,K] = kalman_filter(ssm, mu, S, u(t), y(t), 1, t, dt);
+    [mu,S,mup,Sp,K] = kalman_filter(ssm, mu, S, u(t), y(t));
 
     % particle filter estimation
-    [muParticle, SParticle, Xp] = pf(t, M, A, B, C, X, R, Q, y, u);
+    [muParticle, SParticle, X, Xp] = pf(t, M, A, B, C, X, R, Q, y, u);
 
     % store kalman filter estimates
     mup_S(t) = mup;
@@ -97,4 +95,4 @@ for t = 1:length(T)
 end
 toc
 
-plot_trajectory(4, T, x, y, mu_S, muP_S);
+plot_trajectory(4, T, x, y, mu_S, muP_S, M);

--- a/matlab_simulation/05-estimation/kalman_filter.m
+++ b/matlab_simulation/05-estimation/kalman_filter.m
@@ -1,4 +1,4 @@
-function [mu,S,mup,Sp,K] = kalman_filter(ssm,mu,S,u,y,example,t,freq)
+function [mu,S,mup,Sp,K] = kalman_filter(ssm,mu,S,u,y)
 
 % Performs one iteration of Kalman Filtering
 
@@ -39,26 +39,6 @@ mup = A*mu + B*u;
 Sp = A*S*A' + R;
 
 % Measurement Step: ------------------------------------------------
-% If/else statement added since example 3 is a multirate kalman filter and 
-% requires processing different measurement models at a certain frequency. 
-
-if example == 3
-    % Measures position and velocity
-    if (mod(t,freq) == 0)
-        % Calculate kalman gain
-        K = Sp*C'*inv(C*Sp*C'+Q);
-        % Get new mean of state after measurement
-        mu = mup + K*(y-C*mup);
-        % Get new covaraince of state after measurement
-        S = (eye(n)-K*C)*Sp;
-    else
-        % Only measures velocity
-        K = Sp*C'*inv(C*Sp*C'+Q);
-        mu = mup + K*(y([2 4],:)-C*mup);
-        S = (eye(n)-K*C)*Sp;
-    end
-else % example 1 an 2
-    K = Sp*C'*inv(C*Sp*C'+Q);
-    mu = mup + K*(y-C*mup);
-    S = (eye(n)-K*C)*Sp;
-end
+K = Sp*C'*inv(C*Sp*C'+Q);
+mu = mup + K*(y-C*mup);
+S = (eye(n)-K*C)*Sp;

--- a/matlab_simulation/05-estimation/pf.m
+++ b/matlab_simulation/05-estimation/pf.m
@@ -1,4 +1,4 @@
-function [muParticle, SParticle, Xp] = pf(t, M, A, B, C, X, R, Q, y, u)
+function [muParticle, SParticle, X, Xp] = pf(t, M, A, B, C, X, R, Q, y, u)
     % sample
     for m = 1:M
         e = sqrt(R) * randn(1);

--- a/matlab_simulation/09-utilities/visualization/particle_filter/plot_trajectory.m
+++ b/matlab_simulation/09-utilities/visualization/particle_filter/plot_trajectory.m
@@ -1,4 +1,4 @@
-function plot_trajectory(figure_index, T, x, y, mu_S, muP_S)
+function plot_trajectory(figure_index, T, x, y, mu_S, muP_S, M)
     figure(figure_index);
     clf;
     hold on;
@@ -11,6 +11,6 @@ function plot_trajectory(figure_index, T, x, y, mu_S, muP_S)
     plot(T, 2 * ones(size(T)), 'm--');
     plot(T, 10 * ones(size(T)), 'm--');
     
-    title('State and estimates, M=10');
+    title(sprintf('State and estimates, M=%d', M));
     legend('State', 'Kalman Estimate', 'Particle Estimate')
 end


### PR DESCRIPTION
getting rid of the need to pass in the example number, t, and frequency.

There is some other minor formatting clean up that you may wish to keep or ignore in example3.  

Also, example3 is storing (and never using) the first two columns of the Kalman multiplier (K) in K_S, ignoring the fact that K is a matrix varying in size, either 4x2 or 4x4, depending on the size of the input measurement matrix C.   Since the input changes, I suspect the meaning of the K matrix changes as well, making the K_S() data possibly not that useful.